### PR TITLE
Partition & Error fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -445,9 +445,14 @@ EnvisalinkAccessory.prototype.processAlarmState = function (nextEvent, callback)
 
                     self.insertDelayedEvent('alarm', eventData, nextEvent.callback, 1000);
                 } else {
-                    nextEvent.callback(null, nextEvent.data);
-                    callback();
-                }
+                    try {
+			nextEvent.callback(null, nextEvent.data);
+                    	callback();
+		    }
+		    catch(err) {
+			console.log("Error in nextEvent.callback. "+err);
+                    }
+		}
             });
         } else {
             this.log("Unhandled alarm state: " + nextEvent.data);

--- a/index.js
+++ b/index.js
@@ -344,7 +344,7 @@ EnvisalinkAccessory.prototype.getMotionStatus = function (callback) {
 EnvisalinkAccessory.prototype.getReadyState = function (callback) {
     var currentState = this.status;
     var status = true;
-    if (currentState && currentState.bytes === this.partition) {
+    if (currentState && currentState.partition === this.partition) {
         if (currentState.send == "ready" || currentState.send == "readyforce") {
             status = false;
         }
@@ -355,7 +355,7 @@ EnvisalinkAccessory.prototype.getAlarmState = function (callback) {
     var currentState = this.status;
     var status = Characteristic.SecuritySystemCurrentState.DISARMED;
 
-    if (currentState && currentState.bytes === this.partition) {
+    if (currentState && currentState.partition === this.partition) {
         //Default to disarmed
 
         if (currentState.send == "alarm") {


### PR DESCRIPTION
Code was crashing on line 448 of the original index.js as reported here -[https://github.com/dustindclark/homebridge-envisalink/issues/42]. A try/catch has been added to prevent the code from crashing in this area with no negative side effects.

The second partition wasn't accurately receiving Ready/Alarm states due to a "typo" where currentState.bytes is compared to this.partition, however currentState.bytes is not where the partition number is stored. Changed to currentState.partition now accurately reflects partition status.
