### PR TITLE
Added configuration to allow disabling the alarm proxy within node alarm proxy.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -50,6 +50,12 @@
         "description": "Plugin will update the date/time of your alarm system hourly unless selected",
         "default": true
       },
+      "proxyEnable": {
+        "title": "Enable Alarm proxy",
+        "type": "boolean",
+        "description": "If enabled, a proxy will be used to allow multiple platforms to query the alarm API. This can be set to false if only this plugin will be used with the alarm API.",
+        "default": true
+      },
       "partitions": {
         "title": "Partitions",
         "type": "array",

--- a/index.js
+++ b/index.js
@@ -110,10 +110,11 @@ function EnvisalinkPlatform(log, config) {
             zone: maxZone > 0 ? maxZone : null,
             userPrograms: this.userPrograms.length > 0 ? this.userPrograms.length : null,
             partition: this.partitions ? this.partitions.length : 1,
-            proxyenable: true,
+            proxyenable: config.proxyEnable !== undefined ? config.proxyEnable : true,
             atomicEvents: true,
             logging: false
         };
+        this.log.info("Proxy Enabled: " + this.alarmConfig.proxyenable);
         this.log.info("Zone Config: " + this.alarmConfig.zone);
         this.log.info("User Program Config: " + this.alarmConfig.userPrograms);
         this.alarm = nap.initConfig(this.alarmConfig);


### PR DESCRIPTION
Resolves issue 51 in my setup, as the alarm proxy was disconnecting and failing to recover.  There are a number of issues that can be addressed in nodealarmproxy itself to resolve some of the scenarios, but in the meantime this should help others encountering this problem and not needing the alarm proxy functionality.
Note that I'm not entirely sold on the wording I used for the configuration parameter.  I'd be happy to take suggestions.