### PR TITLE
Handle troubleledoff status, do not assume system disarmed, fix for issue #200

### DIFF
--- a/src/partitionAccessory.ts
+++ b/src/partitionAccessory.ts
@@ -1,6 +1,6 @@
 import {CharacteristicValue, PlatformAccessory} from 'homebridge';
 
-import {EnvisalinkHomebridgePlatform} from './platform';
+import {EnvisalinkHomebridgePlatform, REPORT_ERROR_TXT} from './platform';
 import {MANUFACTURER, MODEL} from './constants';
 import {Partition, PartitionMode} from './types';
 
@@ -128,7 +128,6 @@ export class EnvisalinkPartitionAccessory {
                 break;
             case 'disarmed':
             case 'notready':
-            case 'failedarm':
             case 'failedtoarm':
             case 'useropening':
                 currentState = this.platform.Characteristic.SecuritySystemCurrentState.DISARMED;
@@ -149,10 +148,10 @@ export class EnvisalinkPartitionAccessory {
                 targetState = this.platform.Characteristic.SecuritySystemTargetState.DISARM;
                 break;
             default:
-                // If we do not recognise the security pannel state then we should not assume
-                // that statis is DISARMED.  Leave it unchanged and log warning message.  With
+                // If we do not recognise the security panel state then we should not assume
+                // that status is DISARMED.  Leave it unchanged and log warning message.  With
                 // luck user will report this and provide debug trace.
-                this.platform.log.warn(`Ignoring status '${this.partition.status.text}' (${this.partition.status.description})${this.platform.reportError}`);
+                this.platform.log.warn(`Ignoring status '${this.partition.status.text}' (${this.partition.status.description})${REPORT_ERROR_TXT}`);
         }
 
         if (currentState !== undefined) {

--- a/src/partitionAccessory.ts
+++ b/src/partitionAccessory.ts
@@ -129,6 +129,7 @@ export class EnvisalinkPartitionAccessory {
             case 'disarmed':
             case 'notready':
             case 'failedarm':
+            case 'failedtoarm':
             case 'useropening':
                 currentState = this.platform.Characteristic.SecuritySystemCurrentState.DISARMED;
                 obstructionDetected = true;

--- a/src/partitionAccessory.ts
+++ b/src/partitionAccessory.ts
@@ -139,6 +139,9 @@ export class EnvisalinkPartitionAccessory {
             case 'busy':
             case 'troubleledoff':
                 break;
+            case 'troubleledon':
+                this.platform.log.info(`Ignoring status '${this.partition.status.text}' (${this.partition.status.description})`);
+                break;
             case 'ready':
             case 'readyforce':
                 currentState = this.platform.Characteristic.SecuritySystemCurrentState.DISARMED;

--- a/src/partitionAccessory.ts
+++ b/src/partitionAccessory.ts
@@ -115,6 +115,7 @@ export class EnvisalinkPartitionAccessory {
                 break;
             case 'armed':
             case 'armedbypass':
+            case 'userclosing':
                 if (PartitionMode.Stay === this.partition.status.mode) {
                     currentState = this.platform.Characteristic.SecuritySystemCurrentState.STAY_ARM;
                     targetState = this.platform.Characteristic.SecuritySystemTargetState.STAY_ARM;
@@ -130,6 +131,7 @@ export class EnvisalinkPartitionAccessory {
             case 'notready':
             case 'failedtoarm':
             case 'useropening':
+            case 'specialopening':
                 currentState = this.platform.Characteristic.SecuritySystemCurrentState.DISARMED;
                 obstructionDetected = true;
                 break;

--- a/src/partitionAccessory.ts
+++ b/src/partitionAccessory.ts
@@ -140,6 +140,7 @@ export class EnvisalinkPartitionAccessory {
             case 'troubleledoff':
                 break;
             case 'ready':
+            case 'readyforce':
                 currentState = this.platform.Characteristic.SecuritySystemCurrentState.DISARMED;
                 targetState = this.platform.Characteristic.SecuritySystemTargetState.DISARM;
                 break;

--- a/src/partitionAccessory.ts
+++ b/src/partitionAccessory.ts
@@ -22,7 +22,7 @@ export class EnvisalinkPartitionAccessory {
 
         this.partition = this.accessory.context as Partition;
 
-        this.platform.log.debug(`Setting accessory details for zone: ${JSON.stringify(this.partition, null, 2)}`);
+        this.platform.log.debug(`Setting accessory details for partition: ${JSON.stringify(this.partition, null, 2)}`);
 
         this.bindAccessoryDetails();
         this.bindSecurityPanel();
@@ -137,10 +137,17 @@ export class EnvisalinkPartitionAccessory {
             case 'entrydelay':
             case 'arming':
             case 'busy':
+            case 'troubleledoff':
                 break;
-            default:
+            case 'ready':
                 currentState = this.platform.Characteristic.SecuritySystemCurrentState.DISARMED;
                 targetState = this.platform.Characteristic.SecuritySystemTargetState.DISARM;
+                break;
+            default:
+                // If we do not recognise the security pannel state then we should not assume
+                // that statis is DISARMED.  Leave it unchanged and log warning message.  With
+                // luck user will report this and provide debug trace.
+                this.platform.log.warn(`Ignoring status '${this.partition.status.text}' (${this.partition.status.description})${this.platform.reportError}`);
         }
 
         if (currentState !== undefined) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -26,6 +26,8 @@ import {EnvisalinkPanicAccessory} from './panicAccessory';
 import {EnvisalinkCustomCommandAccessory} from './customCommandAccessory';
 import envisalinkCodes = require('nodealarmproxy/envisalink.js');
 import * as util from 'util';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const packageJSON = require('../package.json');
 
 const MILLIS_BETWEEN_WAIT = 100;
 const MILLIS_MAX_WAIT = 30000;
@@ -49,6 +51,8 @@ export class EnvisalinkHomebridgePlatform implements DynamicPlatformPlugin {
     private zoneConfigs: Map<string, ZoneConfig>;
     private chimeInitialized = false;
     private lastPartitionAction?: Partition;
+
+    public reportError = '\nPlease report all bugs at ' + packageJSON.bugs.url + '\n';
 
     constructor(
         public readonly log: Logger,

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -28,6 +28,7 @@ import envisalinkCodes = require('nodealarmproxy/envisalink.js');
 import * as util from 'util';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageJSON = require('../package.json');
+export const REPORT_ERROR_TXT = '\nPlease report all bugs at ' + packageJSON.bugs.url + '\n';
 
 const MILLIS_BETWEEN_WAIT = 100;
 const MILLIS_MAX_WAIT = 30000;
@@ -51,8 +52,6 @@ export class EnvisalinkHomebridgePlatform implements DynamicPlatformPlugin {
     private zoneConfigs: Map<string, ZoneConfig>;
     private chimeInitialized = false;
     private lastPartitionAction?: Partition;
-
-    public reportError = '\nPlease report all bugs at ' + packageJSON.bugs.url + '\n';
 
     constructor(
         public readonly log: Logger,


### PR DESCRIPTION
Fix for issue #200 This adds support for 'troubleledoff' and 'ready' status.  Also changes the default action to issue a warning message to log and not change the system status to disarmed.

I updated log message for setting accessory details because it was identical to that in zoneAccessory.ts making it difficult to know exactly where the log message came from.

Also pull the bug report URL from package.json and print out that information in the warning message for status that is not handled... so if something similar happens again it might get reported.

Note... I assume that there is a 'troubleledon' status as well.  I consciously left that unhandled... it will fall through to default and print out the warning to log.  I thought that was better than silently ignoring it, because maybe the user might like to know that the trouble LED light is on?

I added 'ready' support as its own case rather than combining with other disarm states... because they (for some reason) set obstructionDetected to true?